### PR TITLE
Fix api path name for deployments in nested subdirectories

### DIFF
--- a/src/main/webapp/app/scripts/app.js
+++ b/src/main/webapp/app/scripts/app.js
@@ -1,7 +1,8 @@
 'use strict';
 // global constants
 var JEngine_Server_URL = window.location.origin;
-var InstanceName = window.location.pathname.split('/')[1];
+// InstanceName is path without leading/trailing slash, e.g. for url with "/bpt/chimera/#/scenario/" it will be "bpt/chimera"
+var InstanceName = window.location.pathname.replace(/^\//, "").replace(/\/$/, "");
 var JUserManagement_Server_URL = window.location.origin;
 // vars defining the URIs of the REST-APIs
 var JCore_REST_Interface = InstanceName + "/api/interface/v2";


### PR DESCRIPTION
The chimera frontend determines a wrong path name for the different APIs when Chimera is deployed in multiple nested subdirectories. Example: When it is deployed in `/bpt/Chimera` it determines its instance name as `bpt` instead of `bpt/Chimera` because currently only the first directory of the path is used, but it should be the whole part. This should be valid as paths in the actual application are represented as client-side path hashes (like `/bpt/Chimera/#/scenario/`), right?