### PR TITLE
feature: webservice content type header

### DIFF
--- a/src/main/java/de/hpi/bpt/chimera/execution/controlnodes/activity/WebServiceTaskInstance.java
+++ b/src/main/java/de/hpi/bpt/chimera/execution/controlnodes/activity/WebServiceTaskInstance.java
@@ -1,6 +1,7 @@
 package de.hpi.bpt.chimera.execution.controlnodes.activity;
 
 import java.util.Map;
+import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
@@ -26,6 +27,7 @@ import org.json.JSONObject;
 public class WebServiceTaskInstance extends AbstractActivityInstance {
 	private static final Logger log = Logger.getLogger(WebServiceTaskInstance.class);
 
+	@Column(length=5000)
 	private String webServiceJson;
 
 	/**
@@ -49,6 +51,7 @@ public class WebServiceTaskInstance extends AbstractActivityInstance {
 		WebTarget target = buildTarget();
 		Response response = executeWebserviceRequest(target);
 		log.debug("Called: " + target + ", response: " + response.getStatus());
+
 		if (response.getStatusInfo().getFamily() == Response.Status.Family.SUCCESSFUL) {
 			String webServiceResponseJson = response.readEntity(String.class);
 			setWebServiceResponse(webServiceResponseJson);
@@ -118,9 +121,9 @@ public class WebServiceTaskInstance extends AbstractActivityInstance {
 			String postBody = getControlNode().getWebServiceBody();
 			String replacedPostBody = this.replaceVariableExpressions(postBody);
 			if ("POST".equals(webServiceMethod)) {
-				return invocationBuilder.post(javax.ws.rs.client.Entity.json(replacedPostBody));
+				return invocationBuilder.post(javax.ws.rs.client.Entity.entity(replacedPostBody, getControlNode().getContentType()));
 			} else {
-				return invocationBuilder.put(javax.ws.rs.client.Entity.json(replacedPostBody));
+				return invocationBuilder.post(javax.ws.rs.client.Entity.entity(replacedPostBody, getControlNode().getContentType()));
 			}
 		default:
 			throw new IllegalArgumentException(webServiceMethod + " is not implemented yet");
@@ -148,6 +151,7 @@ public class WebServiceTaskInstance extends AbstractActivityInstance {
 				headerMap.add(key, value);
 			}
 		}
+		headerMap.add("Content-Type", getControlNode().getContentType());
 		return headerMap;
 	}
 

--- a/src/main/java/de/hpi/bpt/chimera/execution/controlnodes/activity/WebServiceTaskInstance.java
+++ b/src/main/java/de/hpi/bpt/chimera/execution/controlnodes/activity/WebServiceTaskInstance.java
@@ -27,7 +27,7 @@ import org.json.JSONObject;
 public class WebServiceTaskInstance extends AbstractActivityInstance {
 	private static final Logger log = Logger.getLogger(WebServiceTaskInstance.class);
 
-	@Column(length=5000)
+	@Column(length=Integer.MAX_VALUE)
 	private String webServiceJson;
 
 	/**
@@ -123,7 +123,7 @@ public class WebServiceTaskInstance extends AbstractActivityInstance {
 			if ("POST".equals(webServiceMethod)) {
 				return invocationBuilder.post(javax.ws.rs.client.Entity.entity(replacedPostBody, getControlNode().getContentType()));
 			} else {
-				return invocationBuilder.post(javax.ws.rs.client.Entity.entity(replacedPostBody, getControlNode().getContentType()));
+				return invocationBuilder.put(javax.ws.rs.client.Entity.entity(replacedPostBody, getControlNode().getContentType()));
 			}
 		default:
 			throw new IllegalArgumentException(webServiceMethod + " is not implemented yet");

--- a/src/main/java/de/hpi/bpt/chimera/model/fragment/bpmn/activity/WebServiceTask.java
+++ b/src/main/java/de/hpi/bpt/chimera/model/fragment/bpmn/activity/WebServiceTask.java
@@ -1,6 +1,10 @@
 package de.hpi.bpt.chimera.model.fragment.bpmn.activity;
 
+import de.hpi.bpt.chimera.parser.IllegalCaseModelException;
+
 import javax.persistence.Entity;
+import java.util.Arrays;
+import java.util.List;
 
 @Entity
 public class WebServiceTask extends AbstractActivity {
@@ -8,6 +12,7 @@ public class WebServiceTask extends AbstractActivity {
 	private String webServiceMethod;
 	private String webServiceBody;
 	private String webServiceHeader;
+	private String contentType;
 
 	/**
 	 * Email Activities are executed automatically.
@@ -32,6 +37,15 @@ public class WebServiceTask extends AbstractActivity {
 	public String getWebServiceBody() {
 		return webServiceBody;
 	}
+	public String getContentType() {
+		return contentType;
+	}
+	public void setContentType(String contentType) {
+		if (!validateContentType(contentType)) {
+			throw new IllegalCaseModelException("Content-Type not one of the valid options.");
+		}
+		this.contentType = contentType;
+	}
 	public void setWebServiceBody(String webServiceBody) {
 		this.webServiceBody = webServiceBody;
 	}
@@ -40,5 +54,12 @@ public class WebServiceTask extends AbstractActivity {
 	}
 	public void setWebServiceHeader(String webServiceHeader) {
 		this.webServiceHeader = webServiceHeader;
+	}
+
+	private boolean validateContentType(String contentType) {
+		List<String> allowedContentTypes = Arrays.asList("application/json","application/x-www-form-urlencoded",
+				"application/atom+xml", "application/octet-stream", "application/svg+xml", "application/xhtml+xml",
+				"application/xml", "multipart/form-data", "text/html", "text/plain", "text/xml");
+		return allowedContentTypes.contains(contentType);
 	}
 }

--- a/src/main/java/de/hpi/bpt/chimera/parser/fragment/bpmn/ActivityParser.java
+++ b/src/main/java/de/hpi/bpt/chimera/parser/fragment/bpmn/ActivityParser.java
@@ -85,6 +85,7 @@ public class ActivityParser {
 			webServiceTask.setWebServiceMethod(xmlWebTask.getWebServiceMethod());
 			webServiceTask.setWebServiceBody(xmlWebTask.getWebServiceBody());
 			webServiceTask.setWebServiceHeader(xmlWebTask.getWebServiceHeader());
+			webServiceTask.setContentType(xmlWebTask.getContentType());
 			webServiceTasks.add(webServiceTask);
 		}
 		return webServiceTasks;

--- a/src/main/java/de/hpi/bpt/chimera/parser/fragment/bpmn/unmarshaller/xml/WebServiceTask.java
+++ b/src/main/java/de/hpi/bpt/chimera/parser/fragment/bpmn/unmarshaller/xml/WebServiceTask.java
@@ -27,7 +27,10 @@ public class WebServiceTask extends AbstractDataControlNode {
 	String webServiceBody = "";
 
 	@XmlAttribute(name = "griffin:webserviceheader")
-	String getWebServiceHeader = "";
+	String webServiceHeader = "";
+
+	@XmlAttribute(name = "griffin:contenttype")
+	String contentType = "";
 
 
 	public String getWebServiceUrl() {
@@ -43,6 +46,10 @@ public class WebServiceTask extends AbstractDataControlNode {
 	}
 
 	public String getWebServiceHeader() {
-		return getWebServiceHeader;
+		return webServiceHeader;
+	}
+
+	public String getContentType() {
+		return contentType;
 	}
 }


### PR DESCRIPTION
Fixes #108 . Also increases the length of the JSON response that can be saved to `Integer.MAX_VALUE`. 

As opposed to what is written in #108, Chimera only **accepts** `application/json`. This should stay as it is. 
Chimera can now **send different Content-Types**, and validates the input values against the same array that is used in Gryphon. 