### PR TITLE
Fix data object creation bug

### DIFF
--- a/src/main/java/de/hpi/bpt/chimera/rest/v2/DataDependencyRestService.java
+++ b/src/main/java/de/hpi/bpt/chimera/rest/v2/DataDependencyRestService.java
@@ -10,7 +10,6 @@ import de.hpi.bpt.chimera.model.condition.DataStateCondition;
 import de.hpi.bpt.chimera.model.datamodel.DataClass;
 import de.hpi.bpt.chimera.model.datamodel.ObjectLifecycleState;
 import de.hpi.bpt.chimera.rest.AbstractRestService;
-import de.hpi.bpt.chimera.rest.beans.datamodel.DataAttributeJaxBean;
 import de.hpi.bpt.chimera.rest.beans.datamodel.DataAttributeJaxBeanOld;
 import de.hpi.bpt.chimera.rest.beans.datamodel.DataObjectJaxBean;
 
@@ -109,7 +108,7 @@ public class DataDependencyRestService extends AbstractRestService {
 		try {
 			CaseExecutioner caseExecutioner = ExecutionService.getCaseExecutioner(cmId, caseId);
 			AbstractActivityInstance activityInstance = caseExecutioner.getActivityInstance(activityInstanceId);
-
+			
 			Map<DataClass, List<ObjectLifecycleState>> possibleDataClassToObjectLifecycleStates = getPossibleObjectLifecycleTransitions(activityInstance);
 			JSONObject result = new JSONObject();
 			for (Map.Entry<DataClass, List<ObjectLifecycleState>> doToOlc : possibleDataClassToObjectLifecycleStates.entrySet()) {

--- a/src/main/webapp/app/scripts/controllers/scenarioInstanceController.js
+++ b/src/main/webapp/app/scripts/controllers/scenarioInstanceController.js
@@ -302,6 +302,8 @@ angular.module('jfrontend')
             	instanceCtrl.activityOutput[activityInstanceId] = {};
             	instanceCtrl.availableOutputStates[activityInstanceId] = {};
             	instanceCtrl.activityOutputAttributes[activityInstanceId] = {};
+            	instanceCtrl.selectedStates = {};
+                instanceCtrl.attributeValues = {};
                 $http.get(JEngine_Server_URL + '/' + JCore_REST_Interface + '/scenario/' + $routeParams.id
                     + '/instance/' + $routeParams.instanceId + '/activityinstance/' + activityInstanceId + '/output')
                     .success(function (data) {

--- a/src/main/webapp/app/scripts/controllers/scenarioInstanceController.js
+++ b/src/main/webapp/app/scripts/controllers/scenarioInstanceController.js
@@ -269,6 +269,7 @@ angular.module('jfrontend')
             };
 
             this.getActivityInput = function (activityInstanceId) {
+            	instanceCtrl.selectedDataObjectIds = {};
                 $http.get(JEngine_Server_URL + '/' + JCore_REST_Interface + '/scenario/' + $routeParams.id
                     + '/instance/' + $routeParams.instanceId + '/activityinstance/' + activityInstanceId + '/availableInput')
                     .success(function (data) {


### PR DESCRIPTION
## Description
Adapted the frontend so that the selection of data objects is resetted, once an activity is selected for begin.

## Related Issue
Fixes #170 

## How Has This Been Tested?
The casemodel that discovered the bug works now as it should.
