### PR TITLE
Skipping an Event now unlocks its DataObjects

### DIFF
--- a/src/main/java/de/hpi/bpt/chimera/execution/controlnodes/event/AbstractEventInstance.java
+++ b/src/main/java/de/hpi/bpt/chimera/execution/controlnodes/event/AbstractEventInstance.java
@@ -74,6 +74,7 @@ public abstract class AbstractEventInstance extends AbstractDataControlNodeInsta
 
 	@Override
 	public void skip() {
+		getDataManager().unlockDataObjects(this.getSelectedDataObjects());
 		behavior.skip();
 		setState(State.SKIPPED);
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When skipping an Event, i.e. after an EventBasedGateway, it now unlocks its DataObjects.

## Related Issue
32
