### PR TITLE
Allow fragments to be activated immediately via an additional attribute

### DIFF
--- a/src/main/java/de/hpi/bpt/chimera/execution/FragmentInstance.java
+++ b/src/main/java/de/hpi/bpt/chimera/execution/FragmentInstance.java
@@ -70,7 +70,7 @@ public class FragmentInstance {
 	}
 
 	/**
-	 * Start the Case by creating an Instance of the StartEvent and enable the
+	 * Start the Fragment by creating an Instance of the StartEvent and enable the
 	 * ControlFlow of that Instance.
 	 */
 	public void enable() {

--- a/src/main/java/de/hpi/bpt/chimera/execution/FragmentInstance.java
+++ b/src/main/java/de/hpi/bpt/chimera/execution/FragmentInstance.java
@@ -83,6 +83,9 @@ public class FragmentInstance {
 			return;
 		}
 		setState(FragmentState.ENABLED);
+		if(fragment.hasAutomaticActivation()) {
+			activate();
+		}
 		StartEvent startEvent = fragment.getBpmnFragment().getStartEvent();
 		StartEventInstance startEventInstance = (StartEventInstance) ControlNodeInstanceFactory.createControlNodeInstance(startEvent, this);
 		addControlNodeInstance(startEventInstance);

--- a/src/main/java/de/hpi/bpt/chimera/model/fragment/Fragment.java
+++ b/src/main/java/de/hpi/bpt/chimera/model/fragment/Fragment.java
@@ -34,6 +34,7 @@ public class Fragment {
 	private FragmentInstantiationPolicy policy;
 	private boolean hasBound;
 	private int instantiationLimit;
+	private boolean automaticActivation;
 
 	public String getId() {
 		return id;
@@ -83,6 +84,12 @@ public class Fragment {
 
 	public void setPolicy(FragmentInstantiationPolicy policy) {
 		this.policy = policy;
+	}
+
+	public boolean hasAutomaticActivation() { return automaticActivation; }
+
+	public void setAutomaticActivation(boolean automaticActivation) {
+		this.automaticActivation = automaticActivation;
 	}
 
 	public boolean getHasBound() {

--- a/src/main/java/de/hpi/bpt/chimera/parser/fragment/FragmentParser.java
+++ b/src/main/java/de/hpi/bpt/chimera/parser/fragment/FragmentParser.java
@@ -64,6 +64,13 @@ public final class FragmentParser {
 			} else {
 				fragment.setPolicy(FragmentInstantiationPolicy.SEQUENTIAL);
 			}
+
+			if (fragmentJson.has("automaticActivation")) {
+				boolean automaticActivation = fragmentJson.getBoolean("automaticActivation");
+				fragment.setAutomaticActivation(automaticActivation);
+			} else {
+				fragment.setAutomaticActivation(false);
+			}
 			parseBound(fragmentJson, fragment);
 
 			BpmnFragment bmpnFragment = BpmnXmlFragmentParser.parseBpmnXmlFragment(contentXML, parserHelper);


### PR DESCRIPTION
There is a change made in gryphon that shall allow fragments to be active once the data flow is enabled. Therefore some changes have to be made in chimera as well.